### PR TITLE
Fix hardcoded paths: replace /home/jeffq/autonovel with relative paths

### DIFF
--- a/run_drafts.py
+++ b/run_drafts.py
@@ -72,7 +72,7 @@ for ch in chapters:
     results.append((ch, words, slop['slop_penalty'], score))
     
     # Git commit
-    run(f"cd /home/jeffq/autonovel && git add chapters/ch_{ch:02d}.md state.json")
+    run(f"git add chapters/ch_{ch:02d}.md state.json")
     
     # Update state.json
     with open("state.json") as f:

--- a/typeset/build_tex.py
+++ b/typeset/build_tex.py
@@ -2,9 +2,11 @@
 """Build LaTeX source from chapter files."""
 import re
 import os
+from pathlib import Path
 
-CHAPTERS_DIR = "/home/jeffq/autonovel/chapters"
-OUT_DIR = "/home/jeffq/autonovel/typeset"
+BASE_DIR = Path(__file__).parent.parent
+CHAPTERS_DIR = str(BASE_DIR / "chapters")
+OUT_DIR = str(BASE_DIR / "typeset")
 
 def latex_escape(t):
     t = t.replace('&', '\\&')


### PR DESCRIPTION
Fixes #6

## Problem
Several files had hardcoded paths referencing the original author's home directory (`/home/jeffq/autonovel`), making the project non-portable.

## Changes
- **run_drafts.py**: Removed hardcoded `cd /home/jeffq/autonovel` from the git add command — now runs `git add` directly (assumes running from project root, consistent with other commands in the file).
- **typeset/build_tex.py**: Replaced hardcoded `CHAPTERS_DIR` and `OUT_DIR` paths with dynamic paths derived from `Path(__file__).parent.parent`, making them relative to the script location.

## Files modified
- `run_drafts.py`
- `typeset/build_tex.py`