### PR TITLE
fix: handle extended thinking tokens in API responses

### DIFF
--- a/adversarial_edit.py
+++ b/adversarial_edit.py
@@ -13,6 +13,8 @@ import re
 from pathlib import Path
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env")
 
@@ -24,6 +26,7 @@ EDIT_LOG_DIR = BASE_DIR / "edit_logs"
 EDIT_LOG_DIR.mkdir(exist_ok=True)
 
 def call_judge(prompt, max_tokens=8000):
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
     headers = {
         "x-api-key": API_KEY,
@@ -44,7 +47,7 @@ def call_judge(prompt, max_tokens=8000):
     }
     resp = httpx.post(f"{API_BASE}/v1/messages", headers=headers, json=payload, timeout=300)
     resp.raise_for_status()
-    return resp.json()["content"][0]["text"]
+    return extract_text_from_response(resp.json())
 
 def parse_json(text):
     text = text.strip()

--- a/build_arc_summary.py
+++ b/build_arc_summary.py
@@ -9,6 +9,8 @@ import re
 from pathlib import Path
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env")
 
@@ -18,6 +20,7 @@ API_BASE = os.environ.get("AUTONOVEL_API_BASE_URL", "https://api.anthropic.com")
 CHAPTERS_DIR = BASE_DIR / "chapters"
 
 def call_writer(prompt, max_tokens=4000):
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
     headers = {
         "x-api-key": API_KEY,
@@ -33,7 +36,7 @@ def call_writer(prompt, max_tokens=4000):
     }
     resp = httpx.post(f"{API_BASE}/v1/messages", headers=headers, json=payload, timeout=120)
     resp.raise_for_status()
-    return resp.json()["content"][0]["text"]
+    return extract_text_from_response(resp.json())
 
 def extract_key_passages(text):
     """Get opening, closing, and best dialogue from a chapter."""

--- a/build_outline.py
+++ b/build_outline.py
@@ -11,6 +11,8 @@ import re
 from pathlib import Path
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env")
 
@@ -20,6 +22,7 @@ API_BASE = os.environ.get("AUTONOVEL_API_BASE_URL", "https://api.anthropic.com")
 CHAPTERS_DIR = BASE_DIR / "chapters"
 
 def call_model(prompt, max_tokens=1500):
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
     headers = {
         "x-api-key": API_KEY,
@@ -39,7 +42,7 @@ def call_model(prompt, max_tokens=1500):
     }
     resp = httpx.post(f"{API_BASE}/v1/messages", headers=headers, json=payload, timeout=120)
     resp.raise_for_status()
-    text = resp.json()["content"][0]["text"]
+    text = extract_text_from_response(resp.json())
     # Extract JSON from response
     text = text.strip()
     if text.startswith("```"):

--- a/compare_chapters.py
+++ b/compare_chapters.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from datetime import datetime
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env")
 
@@ -25,6 +27,7 @@ API_BASE = os.environ.get("AUTONOVEL_API_BASE_URL", "https://api.anthropic.com")
 CHAPTERS_DIR = BASE_DIR / "chapters"
 
 def call_judge(prompt, max_tokens=4000):
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
     headers = {
         "x-api-key": API_KEY,
@@ -45,7 +48,7 @@ def call_judge(prompt, max_tokens=4000):
     }
     resp = httpx.post(f"{API_BASE}/v1/messages", headers=headers, json=payload, timeout=300)
     resp.raise_for_status()
-    return resp.json()["content"][0]["text"]
+    return extract_text_from_response(resp.json())
 
 def parse_json(text):
     text = text.strip()

--- a/draft_chapter.py
+++ b/draft_chapter.py
@@ -9,6 +9,8 @@ import sys
 from pathlib import Path
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env")
 
@@ -18,6 +20,7 @@ API_BASE = os.environ.get("AUTONOVEL_API_BASE_URL", "https://api.anthropic.com")
 CHAPTERS_DIR = BASE_DIR / "chapters"
 
 def call_writer(prompt, max_tokens=16000):
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
     headers = {
         "x-api-key": API_KEY,
@@ -42,7 +45,7 @@ def call_writer(prompt, max_tokens=16000):
     }
     resp = httpx.post(f"{API_BASE}/v1/messages", headers=headers, json=payload, timeout=600)
     resp.raise_for_status()
-    return resp.json()["content"][0]["text"]
+    return extract_text_from_response(resp.json())
 
 def load_file(path):
     try:

--- a/evaluate.py
+++ b/evaluate.py
@@ -27,6 +27,8 @@ BASE_DIR = Path(__file__).parent
 
 # Load .env file if present
 from dotenv import load_dotenv
+
+from utils import extract_text_from_response, get_max_tokens_with_thinking
 load_dotenv(BASE_DIR / ".env")
 
 # Judge uses Opus 4.6 (harsh, critical). Writer uses Sonnet 4.6 (fast, long context).
@@ -274,6 +276,7 @@ def load_all_chapters():
 
 def call_judge(prompt, max_tokens=2000):
     """Call the Anthropic judge LLM and return its response text."""
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
 
     headers = {
@@ -301,7 +304,7 @@ def call_judge(prompt, max_tokens=2000):
         timeout=180,
     )
     resp.raise_for_status()
-    return resp.json()["content"][0]["text"]
+    return extract_text_from_response(resp.json())
 
 
 def parse_json_response(text):

--- a/gen_art.py
+++ b/gen_art.py
@@ -32,6 +32,8 @@ import subprocess
 from pathlib import Path
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env", override=True)
 
@@ -113,6 +115,7 @@ def download_image(url, dest_path):
 
 
 def call_claude(prompt, max_tokens=1500):
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
     resp = httpx.post(
         f"{ANTHROPIC_BASE}/v1/messages",
@@ -130,7 +133,7 @@ def call_claude(prompt, max_tokens=1500):
         timeout=120,
     )
     resp.raise_for_status()
-    return resp.json()["content"][0]["text"]
+    return extract_text_from_response(resp.json())
 
 
 def load_style():

--- a/gen_art_directions.py
+++ b/gen_art_directions.py
@@ -9,6 +9,8 @@ import re
 from pathlib import Path
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env", override=True)
 
@@ -18,6 +20,7 @@ ANTHROPIC_BASE = os.environ.get("AUTONOVEL_API_BASE_URL", "https://api.anthropic
 
 
 def call_claude(prompt, max_tokens=3000):
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
     resp = httpx.post(
         f"{ANTHROPIC_BASE}/v1/messages",
@@ -35,7 +38,7 @@ def call_claude(prompt, max_tokens=3000):
         timeout=120,
     )
     resp.raise_for_status()
-    return resp.json()["content"][0]["text"]
+    return extract_text_from_response(resp.json())
 
 
 def generate_directions(art_type, style, n=6, world_excerpt=""):

--- a/gen_audiobook_script.py
+++ b/gen_audiobook_script.py
@@ -19,6 +19,8 @@ import re
 from pathlib import Path
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env", override=True)
 
@@ -66,6 +68,7 @@ Rules:
 
 
 def call_claude(prompt, max_tokens=8000):
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
     resp = httpx.post(
         f"{API_BASE}/v1/messages",
@@ -84,7 +87,7 @@ def call_claude(prompt, max_tokens=8000):
         timeout=300,
     )
     resp.raise_for_status()
-    return resp.json()["content"][0]["text"]
+    return extract_text_from_response(resp.json())
 
 
 def parse_chapter(ch_num):

--- a/gen_canon.py
+++ b/gen_canon.py
@@ -7,6 +7,8 @@ import sys
 from pathlib import Path
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env")
 
@@ -15,6 +17,7 @@ API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 API_BASE = os.environ.get("AUTONOVEL_API_BASE_URL", "https://api.anthropic.com")
 
 def call_writer(prompt, max_tokens=16000):
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
     headers = {
         "x-api-key": API_KEY,
@@ -35,7 +38,7 @@ def call_writer(prompt, max_tokens=16000):
     }
     resp = httpx.post(f"{API_BASE}/v1/messages", headers=headers, json=payload, timeout=300)
     resp.raise_for_status()
-    return resp.json()["content"][0]["text"]
+    return extract_text_from_response(resp.json())
 
 world = (BASE_DIR / "world.md").read_text()
 characters = (BASE_DIR / "characters.md").read_text()

--- a/gen_characters.py
+++ b/gen_characters.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env")
 
@@ -16,6 +18,7 @@ API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 API_BASE = os.environ.get("AUTONOVEL_API_BASE_URL", "https://api.anthropic.com")
 
 def call_writer(prompt, max_tokens=16000):
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
     headers = {
         "x-api-key": API_KEY,
@@ -37,7 +40,7 @@ def call_writer(prompt, max_tokens=16000):
     }
     resp = httpx.post(f"{API_BASE}/v1/messages", headers=headers, json=payload, timeout=300)
     resp.raise_for_status()
-    return resp.json()["content"][0]["text"]
+    return extract_text_from_response(resp.json())
 
 seed = (BASE_DIR / "seed.txt").read_text()
 world = (BASE_DIR / "world.md").read_text()

--- a/gen_outline.py
+++ b/gen_outline.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env")
 
@@ -13,6 +15,7 @@ API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 API_BASE = os.environ.get("AUTONOVEL_API_BASE_URL", "https://api.anthropic.com")
 
 def call_writer(prompt, max_tokens=16000):
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
     headers = {
         "x-api-key": API_KEY,
@@ -35,7 +38,7 @@ def call_writer(prompt, max_tokens=16000):
     }
     resp = httpx.post(f"{API_BASE}/v1/messages", headers=headers, json=payload, timeout=600)
     resp.raise_for_status()
-    return resp.json()["content"][0]["text"]
+    return extract_text_from_response(resp.json())
 
 seed = (BASE_DIR / "seed.txt").read_text()
 world = (BASE_DIR / "world.md").read_text()

--- a/gen_outline_part2.py
+++ b/gen_outline_part2.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env")
 
@@ -13,6 +15,7 @@ API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 API_BASE = os.environ.get("AUTONOVEL_API_BASE_URL", "https://api.anthropic.com")
 
 def call_writer(prompt, max_tokens=16000):
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
     headers = {
         "x-api-key": API_KEY,
@@ -33,7 +36,7 @@ def call_writer(prompt, max_tokens=16000):
     }
     resp = httpx.post(f"{API_BASE}/v1/messages", headers=headers, json=payload, timeout=600)
     resp.raise_for_status()
-    return resp.json()["content"][0]["text"]
+    return extract_text_from_response(resp.json())
 
 part1 = open('/tmp/outline_output.md').read()
 mystery = (BASE_DIR / "MYSTERY.md").read_text()

--- a/gen_revision.py
+++ b/gen_revision.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env")
 
@@ -16,6 +18,7 @@ API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 API_BASE = os.environ.get("AUTONOVEL_API_BASE_URL", "https://api.anthropic.com")
 
 def call_writer(prompt, max_tokens=16000):
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
     headers = {
         "x-api-key": API_KEY,
@@ -37,7 +40,7 @@ def call_writer(prompt, max_tokens=16000):
     }
     resp = httpx.post(f"{API_BASE}/v1/messages", headers=headers, json=payload, timeout=600)
     resp.raise_for_status()
-    return resp.json()["content"][0]["text"]
+    return extract_text_from_response(resp.json())
 
 def main():
     ch_num = int(sys.argv[1])

--- a/gen_world.py
+++ b/gen_world.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env")
 
@@ -16,6 +18,7 @@ API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 API_BASE = os.environ.get("AUTONOVEL_API_BASE_URL", "https://api.anthropic.com")
 
 def call_writer(prompt, max_tokens=16000):
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
     headers = {
         "x-api-key": API_KEY,
@@ -38,7 +41,7 @@ def call_writer(prompt, max_tokens=16000):
     }
     resp = httpx.post(f"{API_BASE}/v1/messages", headers=headers, json=payload, timeout=300)
     resp.raise_for_status()
-    return resp.json()["content"][0]["text"]
+    return extract_text_from_response(resp.json())
 
 seed = (BASE_DIR / "seed.txt").read_text()
 voice = (BASE_DIR / "voice.md").read_text()

--- a/reader_panel.py
+++ b/reader_panel.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from datetime import datetime
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env")
 
@@ -120,14 +122,14 @@ def call_reader(reader_key, arc_summary):
     }
     payload = {
         "model": JUDGE_MODEL,
-        "max_tokens": 4000,
+        "max_tokens": get_max_tokens_with_thinking(4000),
         "temperature": 0.7,  # Higher temp for personality
         "system": reader["system"],
         "messages": [{"role": "user", "content": READER_PROMPT.format(arc_summary=arc_summary)}],
     }
     resp = httpx.post(f"{API_BASE}/v1/messages", headers=headers, json=payload, timeout=300)
     resp.raise_for_status()
-    raw = resp.json()["content"][0]["text"]
+    raw = extract_text_from_response(resp.json())
     
     # Parse JSON
     raw = raw.strip()

--- a/review.py
+++ b/review.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from datetime import datetime
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env", override=True)
 
@@ -38,6 +40,7 @@ REVIEW_PROMPT = """Read the below novel, "{title}". Review it first as a literar
 
 def call_opus(prompt, max_tokens=8000):
     """Call Opus with the full manuscript."""
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
     headers = {
         "x-api-key": API_KEY,
@@ -57,7 +60,7 @@ def call_opus(prompt, max_tokens=8000):
         headers=headers, json=payload, timeout=600,
     )
     resp.raise_for_status()
-    return resp.json()["content"][0]["text"]
+    return extract_text_from_response(resp.json())
 
 
 def get_title():

--- a/seed.py
+++ b/seed.py
@@ -15,6 +15,8 @@ import sys
 from pathlib import Path
 from dotenv import load_dotenv
 
+from utils import extract_text_from_response, get_max_tokens_with_thinking
+
 BASE_DIR = Path(__file__).parent
 load_dotenv(BASE_DIR / ".env")
 
@@ -25,6 +27,7 @@ ANTHROPIC_BETA = "context-1m-2025-08-07"
 
 
 def call_writer(prompt, max_tokens=4000):
+    max_tokens = get_max_tokens_with_thinking(max_tokens)
     import httpx
     headers = {
         "x-api-key": ANTHROPIC_API_KEY,
@@ -53,7 +56,7 @@ def call_writer(prompt, max_tokens=4000):
         timeout=120,
     )
     resp.raise_for_status()
-    return resp.json()["content"][0]["text"]
+    return extract_text_from_response(resp.json())
 
 
 GENERATE_PROMPT = """Generate {count} fantasy novel seed concepts. Each should be

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Shared utilities for autonovel scripts.
+"""
+import os
+from pathlib import Path
+
+BASE_DIR = Path(__file__).parent
+
+
+def extract_text_from_response(resp_json):
+    """
+    Extract text content from an Anthropic Messages API response.
+
+    When extended thinking is enabled, the response 'content' array may contain
+    thinking blocks (type="thinking") before the text block (type="text").
+    This function correctly finds and returns the text block content.
+
+    Args:
+        resp_json: The parsed JSON response from the Anthropic API.
+
+    Returns:
+        The text content from the first text block in the response.
+
+    Raises:
+        ValueError: If no text block is found in the response.
+    """
+    content = resp_json.get("content", [])
+
+    # Find the first text block (skip thinking blocks)
+    for block in content:
+        if block.get("type") == "text":
+            return block["text"]
+
+    # Fallback: if content is a simple list with text key (older API format)
+    if content and "text" in content[0]:
+        return content[0]["text"]
+
+    raise ValueError(
+        f"No text block found in response. "
+        f"Block types: {[b.get('type', 'unknown') for b in content]}. "
+        f"Stop reason: {resp_json.get('stop_reason', 'unknown')}"
+    )
+
+
+def get_thinking_budget(max_tokens):
+    """
+    Calculate the thinking token budget to reserve alongside max_tokens.
+
+    When extended thinking is enabled, thinking tokens are counted against
+    the max_tokens budget. This helper reserves a portion for thinking
+    while ensuring enough tokens remain for actual output.
+
+    Args:
+        max_tokens: The total max_tokens value.
+
+    Returns:
+        A dict with 'thinking' config if budget allows, or empty dict.
+    """
+    # Reserve up to 50% of max_tokens for thinking, capped at 16k
+    # Minimum output reserve: 2000 tokens
+    thinking_budget = min(max_tokens // 2, 16000)
+    if thinking_budget >= 1000 and (max_tokens - thinking_budget) >= 2000:
+        return {
+            "type": "enabled",
+            "budget_tokens": thinking_budget,
+        }
+    return {}
+
+
+def get_max_tokens_with_thinking(base_max_tokens):
+    """
+    Return an appropriate max_tokens value that accounts for thinking overhead.
+
+    When models use extended thinking, a significant portion of max_tokens
+    goes to internal reasoning. This function increases the budget to ensure
+    adequate room for both thinking and output.
+
+    Args:
+        base_max_tokens: The desired output token count.
+
+    Returns:
+        The total max_tokens to request (including thinking budget).
+    """
+    # Multiply by 3x to ensure enough room for thinking + output
+    # Minimum: base * 3, capped at 128k
+    return min(base_max_tokens * 3, 128000)


### PR DESCRIPTION
Fixes #5

## Problem
When models use extended thinking/reasoning, the Anthropic API returns thinking blocks (`type="thinking"`) before text blocks. All 18 API-calling scripts assumed `resp.json()["content"][0]["text"]` always works, which fails with `KeyError` when the first content block is a thinking block. Additionally, thinking tokens consume the max_tokens budget.

## Solution
- New `utils.py` with `extract_text_from_response()` that iterates through content array to find first `type="text"` block
- `get_max_tokens_with_thinking()` multiplies max_tokens by 3x to account for thinking overhead
- Updated all 18 API-calling scripts to use these helpers

## Files Changed
- New: `utils.py`
- Modified: `draft_chapter.py`, `gen_outline.py`, `gen_world.py`, `gen_characters.py`, `gen_canon.py`, `gen_revision.py`, `seed.py`, `build_arc_summary.py`, `build_outline.py`, `evaluate.py`, `adversarial_edit.py`, `compare_chapters.py`, `review.py`, `reader_panel.py`, `gen_art.py`, `gen_art_directions.py`, `gen_audiobook_script.py`, `gen_outline_part2.py`