### PR TITLE
fix: write Phase 1 foundation docs to disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 eval_logs/
 edit_logs/
 briefs/
+.outline_part1.md
 __pycache__/
 *.pyc
 .env

--- a/gen_canon.py
+++ b/gen_canon.py
@@ -37,11 +37,12 @@ def call_writer(prompt, max_tokens=16000):
     resp.raise_for_status()
     return resp.json()["content"][0]["text"]
 
-world = (BASE_DIR / "world.md").read_text(encoding="utf-8")
-characters = (BASE_DIR / "characters.md").read_text(encoding="utf-8")
-seed = (BASE_DIR / "seed.txt").read_text(encoding="utf-8")
+def build_prompt(base_dir):
+    world = (base_dir / "world.md").read_text(encoding="utf-8")
+    characters = (base_dir / "characters.md").read_text(encoding="utf-8")
+    seed = (base_dir / "seed.txt").read_text(encoding="utf-8")
 
-prompt = f"""Extract EVERY hard fact from these planning documents into a structured canon database.
+    return f"""Extract EVERY hard fact from these planning documents into a structured canon database.
 A "hard fact" is anything a writer must not contradict: names, ages, dates, physical descriptions,
 rules of the magic system, geography, relationships, established events.
 
@@ -90,10 +91,20 @@ RULES:
 - DO NOT invent facts. Only record what's explicitly stated.
 """
 
-print("Calling writer model...", file=sys.stderr)
-result = call_writer(prompt)
 
-out_path = BASE_DIR / "canon.md"
-out_path.write_text(result, encoding="utf-8")
-print(f"Saved to {out_path}", file=sys.stderr)
-print(result)
+def main(base_dir=None):
+    base_dir = base_dir or BASE_DIR
+    prompt = build_prompt(base_dir)
+
+    print("Calling writer model...", file=sys.stderr)
+    result = call_writer(prompt)
+
+    out_path = base_dir / "canon.md"
+    out_path.write_text(result, encoding="utf-8")
+    print(f"Saved to {out_path}", file=sys.stderr)
+    print(result)
+    return result
+
+
+if __name__ == "__main__":
+    main()

--- a/gen_canon.py
+++ b/gen_canon.py
@@ -37,9 +37,9 @@ def call_writer(prompt, max_tokens=16000):
     resp.raise_for_status()
     return resp.json()["content"][0]["text"]
 
-world = (BASE_DIR / "world.md").read_text()
-characters = (BASE_DIR / "characters.md").read_text()
-seed = (BASE_DIR / "seed.txt").read_text()
+world = (BASE_DIR / "world.md").read_text(encoding="utf-8")
+characters = (BASE_DIR / "characters.md").read_text(encoding="utf-8")
+seed = (BASE_DIR / "seed.txt").read_text(encoding="utf-8")
 
 prompt = f"""Extract EVERY hard fact from these planning documents into a structured canon database.
 A "hard fact" is anything a writer must not contradict: names, ages, dates, physical descriptions,
@@ -92,4 +92,8 @@ RULES:
 
 print("Calling writer model...", file=sys.stderr)
 result = call_writer(prompt)
+
+out_path = BASE_DIR / "canon.md"
+out_path.write_text(result, encoding="utf-8")
+print(f"Saved to {out_path}", file=sys.stderr)
 print(result)

--- a/gen_characters.py
+++ b/gen_characters.py
@@ -39,16 +39,17 @@ def call_writer(prompt, max_tokens=16000):
     resp.raise_for_status()
     return resp.json()["content"][0]["text"]
 
-seed = (BASE_DIR / "seed.txt").read_text(encoding="utf-8")
-world = (BASE_DIR / "world.md").read_text(encoding="utf-8")
+def build_prompt(base_dir):
+    seed = (base_dir / "seed.txt").read_text(encoding="utf-8")
+    world = (base_dir / "world.md").read_text(encoding="utf-8")
 
-# Voice Part 2 only
-voice = (BASE_DIR / "voice.md").read_text(encoding="utf-8")
-voice_lines = voice.split('\n')
-part2_start = next(i for i, l in enumerate(voice_lines) if 'Part 2' in l)
-voice_part2 = '\n'.join(voice_lines[part2_start:])
+    # Voice Part 2 only
+    voice = (base_dir / "voice.md").read_text(encoding="utf-8")
+    voice_lines = voice.split('\n')
+    part2_start = next(i for i, l in enumerate(voice_lines) if 'Part 2' in l)
+    voice_part2 = '\n'.join(voice_lines[part2_start:])
 
-prompt = f"""Build a complete character registry for this fantasy novel. This is CHARACTERS.MD --
+    return f"""Build a complete character registry for this fantasy novel. This is CHARACTERS.MD --
 the definitive reference for WHO exists in this story, what drives them, how they speak,
 and what secrets they carry.
 
@@ -143,10 +144,20 @@ IMPORTANT:
 - Target ~3000-4000 words. Dense character work, not padding.
 """
 
-print("Calling writer model...", file=sys.stderr)
-result = call_writer(prompt)
 
-out_path = BASE_DIR / "characters.md"
-out_path.write_text(result, encoding="utf-8")
-print(f"Saved to {out_path}", file=sys.stderr)
-print(result)
+def main(base_dir=None):
+    base_dir = base_dir or BASE_DIR
+    prompt = build_prompt(base_dir)
+
+    print("Calling writer model...", file=sys.stderr)
+    result = call_writer(prompt)
+
+    out_path = base_dir / "characters.md"
+    out_path.write_text(result, encoding="utf-8")
+    print(f"Saved to {out_path}", file=sys.stderr)
+    print(result)
+    return result
+
+
+if __name__ == "__main__":
+    main()

--- a/gen_characters.py
+++ b/gen_characters.py
@@ -39,11 +39,11 @@ def call_writer(prompt, max_tokens=16000):
     resp.raise_for_status()
     return resp.json()["content"][0]["text"]
 
-seed = (BASE_DIR / "seed.txt").read_text()
-world = (BASE_DIR / "world.md").read_text()
+seed = (BASE_DIR / "seed.txt").read_text(encoding="utf-8")
+world = (BASE_DIR / "world.md").read_text(encoding="utf-8")
 
 # Voice Part 2 only
-voice = (BASE_DIR / "voice.md").read_text()
+voice = (BASE_DIR / "voice.md").read_text(encoding="utf-8")
 voice_lines = voice.split('\n')
 part2_start = next(i for i, l in enumerate(voice_lines) if 'Part 2' in l)
 voice_part2 = '\n'.join(voice_lines[part2_start:])
@@ -145,4 +145,8 @@ IMPORTANT:
 
 print("Calling writer model...", file=sys.stderr)
 result = call_writer(prompt)
+
+out_path = BASE_DIR / "characters.md"
+out_path.write_text(result, encoding="utf-8")
+print(f"Saved to {out_path}", file=sys.stderr)
 print(result)

--- a/gen_outline.py
+++ b/gen_outline.py
@@ -37,14 +37,14 @@ def call_writer(prompt, max_tokens=16000):
     resp.raise_for_status()
     return resp.json()["content"][0]["text"]
 
-seed = (BASE_DIR / "seed.txt").read_text()
-world = (BASE_DIR / "world.md").read_text()
-characters = (BASE_DIR / "characters.md").read_text()
-mystery = (BASE_DIR / "MYSTERY.md").read_text()
-craft = (BASE_DIR / "CRAFT.md").read_text()
+seed = (BASE_DIR / "seed.txt").read_text(encoding="utf-8")
+world = (BASE_DIR / "world.md").read_text(encoding="utf-8")
+characters = (BASE_DIR / "characters.md").read_text(encoding="utf-8")
+mystery = (BASE_DIR / "MYSTERY.md").read_text(encoding="utf-8")
+craft = (BASE_DIR / "CRAFT.md").read_text(encoding="utf-8")
 
 # Voice Part 2 only
-voice = (BASE_DIR / "voice.md").read_text()
+voice = (BASE_DIR / "voice.md").read_text(encoding="utf-8")
 voice_lines = voice.split('\n')
 part2_start = next(i for i, l in enumerate(voice_lines) if 'Part 2' in l)
 voice_part2 = '\n'.join(voice_lines[part2_start:])
@@ -131,4 +131,11 @@ CONSTRAINTS:
 
 print("Calling writer model...", file=sys.stderr)
 result = call_writer(prompt)
+
+out_path = BASE_DIR / "outline.md"
+out_path.write_text(result, encoding="utf-8")
+# Snapshot so gen_outline_part2.py has a stable part-1 handoff even if
+# outline.md already holds a previous run's merged part1+part2 content.
+(BASE_DIR / ".outline_part1.md").write_text(result, encoding="utf-8")
+print(f"Saved to {out_path}", file=sys.stderr)
 print(result)

--- a/gen_outline.py
+++ b/gen_outline.py
@@ -37,19 +37,20 @@ def call_writer(prompt, max_tokens=16000):
     resp.raise_for_status()
     return resp.json()["content"][0]["text"]
 
-seed = (BASE_DIR / "seed.txt").read_text(encoding="utf-8")
-world = (BASE_DIR / "world.md").read_text(encoding="utf-8")
-characters = (BASE_DIR / "characters.md").read_text(encoding="utf-8")
-mystery = (BASE_DIR / "MYSTERY.md").read_text(encoding="utf-8")
-craft = (BASE_DIR / "CRAFT.md").read_text(encoding="utf-8")
+def build_prompt(base_dir):
+    seed = (base_dir / "seed.txt").read_text(encoding="utf-8")
+    world = (base_dir / "world.md").read_text(encoding="utf-8")
+    characters = (base_dir / "characters.md").read_text(encoding="utf-8")
+    mystery = (base_dir / "MYSTERY.md").read_text(encoding="utf-8")
+    craft = (base_dir / "CRAFT.md").read_text(encoding="utf-8")
 
-# Voice Part 2 only
-voice = (BASE_DIR / "voice.md").read_text(encoding="utf-8")
-voice_lines = voice.split('\n')
-part2_start = next(i for i, l in enumerate(voice_lines) if 'Part 2' in l)
-voice_part2 = '\n'.join(voice_lines[part2_start:])
+    # Voice Part 2 only
+    voice = (base_dir / "voice.md").read_text(encoding="utf-8")
+    voice_lines = voice.split('\n')
+    part2_start = next(i for i, l in enumerate(voice_lines) if 'Part 2' in l)
+    voice_part2 = '\n'.join(voice_lines[part2_start:])
 
-prompt = f"""Build a complete chapter outline for this fantasy novel. Target: 22-26 chapters,
+    return f"""Build a complete chapter outline for this fantasy novel. Target: 22-26 chapters,
 ~80,000 words total (~3,000-4,000 words per chapter).
 
 SEED CONCEPT:
@@ -129,13 +130,32 @@ CONSTRAINTS:
 - The foreshadowing ledger must have plant-to-payoff distances of at least 3 chapters
 """
 
-print("Calling writer model...", file=sys.stderr)
-result = call_writer(prompt)
 
-out_path = BASE_DIR / "outline.md"
-out_path.write_text(result, encoding="utf-8")
-# Snapshot so gen_outline_part2.py has a stable part-1 handoff even if
-# outline.md already holds a previous run's merged part1+part2 content.
-(BASE_DIR / ".outline_part1.md").write_text(result, encoding="utf-8")
-print(f"Saved to {out_path}", file=sys.stderr)
-print(result)
+def main(base_dir=None):
+    base_dir = base_dir or BASE_DIR
+
+    # Clear any stale part-1 snapshot from a prior foundation iteration before
+    # calling the model. The snapshot is gitignored, so `git reset --hard`
+    # during foundation retries does not remove it — if this run fails before
+    # reaching the write below, a leftover snapshot from an earlier iteration
+    # could otherwise be picked up by gen_outline_part2.py.
+    part1_snapshot = base_dir / ".outline_part1.md"
+    part1_snapshot.unlink(missing_ok=True)
+
+    prompt = build_prompt(base_dir)
+
+    print("Calling writer model...", file=sys.stderr)
+    result = call_writer(prompt)
+
+    out_path = base_dir / "outline.md"
+    out_path.write_text(result, encoding="utf-8")
+    # Snapshot so gen_outline_part2.py has a stable part-1 handoff even if
+    # outline.md already holds a previous run's merged part1+part2 content.
+    part1_snapshot.write_text(result, encoding="utf-8")
+    print(f"Saved to {out_path}", file=sys.stderr)
+    print(result)
+    return result
+
+
+if __name__ == "__main__":
+    main()

--- a/gen_outline.py
+++ b/gen_outline.py
@@ -133,16 +133,19 @@ CONSTRAINTS:
 
 def main(base_dir=None):
     base_dir = base_dir or BASE_DIR
+    part1_snapshot = base_dir / ".outline_part1.md"
+
+    # Load inputs and build the prompt first, so a missing/unreadable input
+    # file (seed.txt, world.md, etc.) fails loudly without touching the
+    # existing snapshot.
+    prompt = build_prompt(base_dir)
 
     # Clear any stale part-1 snapshot from a prior foundation iteration before
     # calling the model. The snapshot is gitignored, so `git reset --hard`
     # during foundation retries does not remove it — if this run fails before
     # reaching the write below, a leftover snapshot from an earlier iteration
     # could otherwise be picked up by gen_outline_part2.py.
-    part1_snapshot = base_dir / ".outline_part1.md"
     part1_snapshot.unlink(missing_ok=True)
-
-    prompt = build_prompt(base_dir)
 
     print("Calling writer model...", file=sys.stderr)
     result = call_writer(prompt)

--- a/gen_outline_part2.py
+++ b/gen_outline_part2.py
@@ -35,21 +35,8 @@ def call_writer(prompt, max_tokens=16000):
     resp.raise_for_status()
     return resp.json()["content"][0]["text"]
 
-outline_path = BASE_DIR / "outline.md"
-part1_snapshot = BASE_DIR / ".outline_part1.md"
-if not part1_snapshot.exists():
-    sys.exit(
-        f"ERROR: {part1_snapshot} not found. Run gen_outline.py first — "
-        "outline.md may already hold merged part1+part2 content and can't "
-        "be reliably reused as a fresh part-1 input."
-    )
-# Read from the stable part-1 snapshot gen_outline.py writes alongside
-# outline.md (rather than outline.md itself), so a re-run of this script
-# never appends onto its own previous merged output.
-part1 = part1_snapshot.read_text(encoding="utf-8")
-mystery = (BASE_DIR / "MYSTERY.md").read_text(encoding="utf-8")
-
-prompt = f"""Here are the first 17 chapters of a 24-chapter outline for "The Second Son of the House of Bells."
+def build_prompt(part1, mystery):
+    return f"""Here are the first 17 chapters of a 24-chapter outline for "The Second Son of the House of Bells."
 The outline was cut off mid-chapter-17. Continue from where it left off, then complete chapters 18-24,
 then write the Foreshadowing Ledger.
 
@@ -88,9 +75,37 @@ REMEMBER:
 - At least one quiet chapter in the back half
 """
 
-print("Calling writer model...", file=sys.stderr)
-result = call_writer(prompt)
 
-outline_path.write_text(part1 + "\n\n" + result, encoding="utf-8")
-print(f"Saved to {outline_path}", file=sys.stderr)
-print(result)
+def main(base_dir=None):
+    base_dir = base_dir or BASE_DIR
+
+    outline_path = base_dir / "outline.md"
+    part1_snapshot = base_dir / ".outline_part1.md"
+    if not part1_snapshot.exists():
+        sys.exit(
+            f"ERROR: {part1_snapshot} not found. Run gen_outline.py first — "
+            "outline.md may already hold merged part1+part2 content and can't "
+            "be reliably reused as a fresh part-1 input."
+        )
+    # Read from the stable part-1 snapshot gen_outline.py writes alongside
+    # outline.md (rather than outline.md itself), so a re-run of this script
+    # never appends onto its own previous merged output.
+    part1 = part1_snapshot.read_text(encoding="utf-8")
+    mystery = (base_dir / "MYSTERY.md").read_text(encoding="utf-8")
+
+    prompt = build_prompt(part1, mystery)
+
+    print("Calling writer model...", file=sys.stderr)
+    result = call_writer(prompt)
+
+    # Merge part1 + part2 into outline.md once per run — never append onto a
+    # previous merge — so rerunning part 2 cannot duplicate chapters.
+    merged = part1 + "\n\n" + result
+    outline_path.write_text(merged, encoding="utf-8")
+    print(f"Saved to {outline_path}", file=sys.stderr)
+    print(result)
+    return merged
+
+
+if __name__ == "__main__":
+    main()

--- a/gen_outline_part2.py
+++ b/gen_outline_part2.py
@@ -35,8 +35,19 @@ def call_writer(prompt, max_tokens=16000):
     resp.raise_for_status()
     return resp.json()["content"][0]["text"]
 
-part1 = open('/tmp/outline_output.md').read()
-mystery = (BASE_DIR / "MYSTERY.md").read_text()
+outline_path = BASE_DIR / "outline.md"
+part1_snapshot = BASE_DIR / ".outline_part1.md"
+if not part1_snapshot.exists():
+    sys.exit(
+        f"ERROR: {part1_snapshot} not found. Run gen_outline.py first — "
+        "outline.md may already hold merged part1+part2 content and can't "
+        "be reliably reused as a fresh part-1 input."
+    )
+# Read from the stable part-1 snapshot gen_outline.py writes alongside
+# outline.md (rather than outline.md itself), so a re-run of this script
+# never appends onto its own previous merged output.
+part1 = part1_snapshot.read_text(encoding="utf-8")
+mystery = (BASE_DIR / "MYSTERY.md").read_text(encoding="utf-8")
 
 prompt = f"""Here are the first 17 chapters of a 24-chapter outline for "The Second Son of the House of Bells."
 The outline was cut off mid-chapter-17. Continue from where it left off, then complete chapters 18-24,
@@ -79,4 +90,7 @@ REMEMBER:
 
 print("Calling writer model...", file=sys.stderr)
 result = call_writer(prompt)
+
+outline_path.write_text(part1 + "\n\n" + result, encoding="utf-8")
+print(f"Saved to {outline_path}", file=sys.stderr)
 print(result)

--- a/gen_world.py
+++ b/gen_world.py
@@ -40,16 +40,17 @@ def call_writer(prompt, max_tokens=16000):
     resp.raise_for_status()
     return resp.json()["content"][0]["text"]
 
-seed = (BASE_DIR / "seed.txt").read_text(encoding="utf-8")
-voice = (BASE_DIR / "voice.md").read_text(encoding="utf-8")
-craft = (BASE_DIR / "CRAFT.md").read_text(encoding="utf-8")
+def build_prompt(base_dir):
+    seed = (base_dir / "seed.txt").read_text(encoding="utf-8")
+    voice = (base_dir / "voice.md").read_text(encoding="utf-8")
+    craft = (base_dir / "CRAFT.md").read_text(encoding="utf-8")
 
-# Extract voice Part 2 only (the novel-specific voice)
-voice_lines = voice.split('\n')
-part2_start = next(i for i, l in enumerate(voice_lines) if 'Part 2' in l)
-voice_part2 = '\n'.join(voice_lines[part2_start:])
+    # Extract voice Part 2 only (the novel-specific voice)
+    voice_lines = voice.split('\n')
+    part2_start = next(i for i, l in enumerate(voice_lines) if 'Part 2' in l)
+    voice_part2 = '\n'.join(voice_lines[part2_start:])
 
-prompt = f"""Build a complete world bible for this fantasy novel. This is the WORLD.MD file -- 
+    return f"""Build a complete world bible for this fantasy novel. This is the WORLD.MD file -- 
 the definitive reference for everything that EXISTS in this world. A writer should be able 
 to resolve any worldbuilding question from this document alone.
 
@@ -121,10 +122,20 @@ IMPORTANT:
 - Target ~3000-4000 words. Dense, not padded.
 """
 
-print("Calling writer model...", file=sys.stderr)
-result = call_writer(prompt)
 
-out_path = BASE_DIR / "world.md"
-out_path.write_text(result, encoding="utf-8")
-print(f"Saved to {out_path}", file=sys.stderr)
-print(result)
+def main(base_dir=None):
+    base_dir = base_dir or BASE_DIR
+    prompt = build_prompt(base_dir)
+
+    print("Calling writer model...", file=sys.stderr)
+    result = call_writer(prompt)
+
+    out_path = base_dir / "world.md"
+    out_path.write_text(result, encoding="utf-8")
+    print(f"Saved to {out_path}", file=sys.stderr)
+    print(result)
+    return result
+
+
+if __name__ == "__main__":
+    main()

--- a/gen_world.py
+++ b/gen_world.py
@@ -40,9 +40,9 @@ def call_writer(prompt, max_tokens=16000):
     resp.raise_for_status()
     return resp.json()["content"][0]["text"]
 
-seed = (BASE_DIR / "seed.txt").read_text()
-voice = (BASE_DIR / "voice.md").read_text()
-craft = (BASE_DIR / "CRAFT.md").read_text()
+seed = (BASE_DIR / "seed.txt").read_text(encoding="utf-8")
+voice = (BASE_DIR / "voice.md").read_text(encoding="utf-8")
+craft = (BASE_DIR / "CRAFT.md").read_text(encoding="utf-8")
 
 # Extract voice Part 2 only (the novel-specific voice)
 voice_lines = voice.split('\n')
@@ -123,4 +123,8 @@ IMPORTANT:
 
 print("Calling writer model...", file=sys.stderr)
 result = call_writer(prompt)
+
+out_path = BASE_DIR / "world.md"
+out_path.write_text(result, encoding="utf-8")
+print(f"Saved to {out_path}", file=sys.stderr)
 print(result)

--- a/tests/test_phase1_foundation.py
+++ b/tests/test_phase1_foundation.py
@@ -108,6 +108,22 @@ class TestGenOutlineStaleSnapshot(FoundationFixtureTestCase):
         outline_path = self.base_dir / "outline.md"
         self.assertEqual(outline_path.read_text(encoding="utf-8"), "FRESH PART 1")
 
+    def test_missing_input_leaves_existing_snapshot_untouched(self):
+        """If loading inputs fails (e.g. a required file is missing), the
+        existing snapshot must not be deleted -- deleting it before the
+        prompt is safely built would strand gen_outline_part2.py with no
+        usable part-1 handoff even though a valid one existed."""
+        snapshot = self.base_dir / ".outline_part1.md"
+        snapshot.write_text("EXISTING VALID PART 1", encoding="utf-8")
+        (self.base_dir / "seed.txt").unlink()
+
+        with mock.patch.object(gen_outline, "call_writer", return_value="SHOULD NOT BE CALLED"):
+            with self.assertRaises(FileNotFoundError):
+                gen_outline.main(base_dir=self.base_dir)
+
+        self.assertTrue(snapshot.exists())
+        self.assertEqual(snapshot.read_text(encoding="utf-8"), "EXISTING VALID PART 1")
+
     def test_writes_outline_and_snapshot_from_clean_state(self):
         snapshot = self.base_dir / ".outline_part1.md"
         self.assertFalse(snapshot.exists())

--- a/tests/test_phase1_foundation.py
+++ b/tests/test_phase1_foundation.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""
+Smoke tests for the Phase 1 foundation generators (gen_world, gen_characters,
+gen_outline, gen_outline_part2, gen_canon).
+
+These stub out call_writer() so no live network/API calls are made. They
+verify two contracts that matter for the multi-iteration foundation loop in
+run_pipeline.py:
+
+1. Each generator writes its output file(s) to disk.
+2. gen_outline.py clears any stale `.outline_part1.md` snapshot from a prior
+   iteration before generating a new one, and gen_outline_part2.py merges
+   part1 + part2 into outline.md exactly once per run (no duplicated
+   chapters on rerun).
+
+Run with: python -m unittest discover -s tests -v
+"""
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import gen_canon  # noqa: E402
+import gen_characters  # noqa: E402
+import gen_outline  # noqa: E402
+import gen_outline_part2  # noqa: E402
+import gen_world  # noqa: E402
+
+
+def _write(path: Path, name: str, content: str = "placeholder\n") -> None:
+    (path / name).write_text(content, encoding="utf-8")
+
+
+class FoundationFixtureTestCase(unittest.TestCase):
+    """Base class that sets up a temp base_dir with the input files the
+    Phase 1 generators expect, so each generator can be exercised in
+    isolation without touching the real repo directory."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.base_dir = Path(self._tmpdir.name)
+
+        _write(self.base_dir, "seed.txt", "A boy who can hear the bells.\n")
+        _write(
+            self.base_dir,
+            "voice.md",
+            "# Voice\n\n## Part 1\ngeneric voice notes\n\n## Part 2\nnovel-specific voice notes\n",
+        )
+        _write(self.base_dir, "CRAFT.md", "craft reference notes\n")
+        _write(self.base_dir, "MYSTERY.md", "the central mystery\n")
+        _write(self.base_dir, "world.md", "# World\nplaceholder world bible\n")
+        _write(self.base_dir, "characters.md", "# Characters\nplaceholder registry\n")
+
+
+class TestGenWorld(FoundationFixtureTestCase):
+    def test_writes_world_md(self):
+        with mock.patch.object(gen_world, "call_writer", return_value="WORLD CONTENT"):
+            result = gen_world.main(base_dir=self.base_dir)
+
+        self.assertEqual(result, "WORLD CONTENT")
+        out_path = self.base_dir / "world.md"
+        self.assertTrue(out_path.exists())
+        self.assertEqual(out_path.read_text(encoding="utf-8"), "WORLD CONTENT")
+
+
+class TestGenCharacters(FoundationFixtureTestCase):
+    def test_writes_characters_md(self):
+        with mock.patch.object(gen_characters, "call_writer", return_value="CHARACTERS CONTENT"):
+            result = gen_characters.main(base_dir=self.base_dir)
+
+        self.assertEqual(result, "CHARACTERS CONTENT")
+        out_path = self.base_dir / "characters.md"
+        self.assertTrue(out_path.exists())
+        self.assertEqual(out_path.read_text(encoding="utf-8"), "CHARACTERS CONTENT")
+
+
+class TestGenCanon(FoundationFixtureTestCase):
+    def test_writes_canon_md(self):
+        with mock.patch.object(gen_canon, "call_writer", return_value="CANON CONTENT"):
+            result = gen_canon.main(base_dir=self.base_dir)
+
+        self.assertEqual(result, "CANON CONTENT")
+        out_path = self.base_dir / "canon.md"
+        self.assertTrue(out_path.exists())
+        self.assertEqual(out_path.read_text(encoding="utf-8"), "CANON CONTENT")
+
+
+class TestGenOutlineStaleSnapshot(FoundationFixtureTestCase):
+    def test_clears_stale_snapshot_before_regenerating(self):
+        snapshot = self.base_dir / ".outline_part1.md"
+        snapshot.write_text("STALE PART 1 FROM A PRIOR ITERATION", encoding="utf-8")
+
+        with mock.patch.object(gen_outline, "call_writer", return_value="FRESH PART 1"):
+            result = gen_outline.main(base_dir=self.base_dir)
+
+        self.assertEqual(result, "FRESH PART 1")
+        # The stale snapshot must be gone and replaced with the fresh output,
+        # never silently reused by gen_outline_part2.py.
+        self.assertEqual(snapshot.read_text(encoding="utf-8"), "FRESH PART 1")
+        self.assertNotIn("STALE", snapshot.read_text(encoding="utf-8"))
+
+        outline_path = self.base_dir / "outline.md"
+        self.assertEqual(outline_path.read_text(encoding="utf-8"), "FRESH PART 1")
+
+    def test_writes_outline_and_snapshot_from_clean_state(self):
+        snapshot = self.base_dir / ".outline_part1.md"
+        self.assertFalse(snapshot.exists())
+
+        with mock.patch.object(gen_outline, "call_writer", return_value="PART 1 TEXT"):
+            gen_outline.main(base_dir=self.base_dir)
+
+        self.assertTrue(snapshot.exists())
+        self.assertEqual(snapshot.read_text(encoding="utf-8"), "PART 1 TEXT")
+        self.assertEqual(
+            (self.base_dir / "outline.md").read_text(encoding="utf-8"), "PART 1 TEXT"
+        )
+
+
+class TestGenOutlinePart2Merge(FoundationFixtureTestCase):
+    def test_errors_without_snapshot(self):
+        with self.assertRaises(SystemExit):
+            gen_outline_part2.main(base_dir=self.base_dir)
+
+    def test_merges_part1_and_part2_once(self):
+        snapshot = self.base_dir / ".outline_part1.md"
+        snapshot.write_text("CHAPTERS 1-17", encoding="utf-8")
+
+        with mock.patch.object(gen_outline_part2, "call_writer", return_value="CHAPTERS 18-24 + LEDGER"):
+            merged = gen_outline_part2.main(base_dir=self.base_dir)
+
+        outline_path = self.base_dir / "outline.md"
+        on_disk = outline_path.read_text(encoding="utf-8")
+        self.assertEqual(merged, on_disk)
+        self.assertIn("CHAPTERS 1-17", on_disk)
+        self.assertIn("CHAPTERS 18-24 + LEDGER", on_disk)
+        # Exactly one occurrence each -- no duplication.
+        self.assertEqual(on_disk.count("CHAPTERS 1-17"), 1)
+        self.assertEqual(on_disk.count("CHAPTERS 18-24 + LEDGER"), 1)
+
+    def test_rerun_does_not_duplicate_chapters(self):
+        """Re-running part 2 always reads from the untouched part-1 snapshot
+        and overwrites outline.md wholesale, so chapters never accumulate
+        across repeated runs (e.g. re-running after a foundation retry)."""
+        snapshot = self.base_dir / ".outline_part1.md"
+        snapshot.write_text("CHAPTERS 1-17", encoding="utf-8")
+
+        with mock.patch.object(gen_outline_part2, "call_writer", return_value="RUN A CONTENT"):
+            gen_outline_part2.main(base_dir=self.base_dir)
+
+        with mock.patch.object(gen_outline_part2, "call_writer", return_value="RUN B CONTENT"):
+            gen_outline_part2.main(base_dir=self.base_dir)
+
+        on_disk = (self.base_dir / "outline.md").read_text(encoding="utf-8")
+        self.assertEqual(on_disk.count("CHAPTERS 1-17"), 1)
+        self.assertNotIn("RUN A CONTENT", on_disk)
+        self.assertEqual(on_disk.count("RUN B CONTENT"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `gen_world.py`, `gen_characters.py`, `gen_outline.py`, and `gen_canon.py` only printed LLM output to stdout; `run_pipeline.py`'s `uv_run()` discards that, so `world.md` / `characters.md` / `outline.md` / `canon.md` stayed empty templates forever (#17).
- Each script now writes its result with `Path.write_text(..., encoding=utf-8)` (same pattern as `draft_chapter.py`), and matching `read_text` calls pin UTF-8 for Windows/cp1252 safety.
- `gen_outline_part2.py` no longer reads a hardcoded `/tmp/outline_output.md`; it uses a small part-1 snapshot written alongside `outline.md` (Windows-safe, re-run safe).

## Follow-up hardening

- `gen_outline.py` now clears any stale `.outline_part1.md` snapshot up front (after loading inputs, before the model call). The snapshot is gitignored, so `git reset --hard` during a foundation retry doesn't remove it -- without this, a `gen_outline.py` run that fails before rewriting the snapshot could leave `gen_outline_part2.py` silently reusing a stale part-1 from an earlier iteration. Now a failed regenerate leaves *no* snapshot (part 2 errors loudly) instead of a *stale* one (part 2 silently uses wrong data). Input-loading failures (missing/unreadable seed/world/etc.) are checked before the snapshot is touched, so a valid existing snapshot survives those.
- `gen_world.py`, `gen_characters.py`, `gen_outline.py`, `gen_outline_part2.py`, and `gen_canon.py` bodies are wrapped in `main(base_dir=...)` (guarded by `if __name__ == __main__:`) so they're import-safe and stubbable in tests, with no behavior change for normal CLI usage.
- Added a stdlib `unittest` smoke suite (`tests/test_phase1_foundation.py`, no pytest dependency, no live network calls) covering:
  - Each generator writes its output file.
  - The stale part-1 snapshot is cleared before a fresh outline is generated, and untouched if input loading fails first.
  - Re-running outline part 2 merges part1+part2 into `outline.md` exactly once per run and never duplicates chapters across reruns.

## Related

Fixes #17

## Why not PR #14?

Open [PR #14](https://github.com/NousResearch/autonovel/pull/14) includes this fix but buries it in a large generated-novel dump (~42 files / +15k lines). This branch is the minimal reviewable alternative: generator scripts + `.gitignore` + a small test suite.

## Test plan

- [x] Run `gen_world.py` (or the foundation phase of `run_pipeline.py`) and confirm `world.md` is non-empty on disk
- [x] Same for characters / outline / canon
- [x] On Windows, confirm outline part-2 no longer depends on `/tmp/outline_output.md`
- [x] Confirm re-running `gen_outline_part2.py` alone does not duplicate chapters when the part-1 snapshot is present
- [x] `python -m unittest discover -s tests -v` passes (9 tests, no network calls)